### PR TITLE
Added missing head closing tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -102,5 +102,5 @@
 
     </script>
   </body>
-
+</head>
 </html>


### PR DESCRIPTION
**Brief Description of Fix**
I fixed the missing head closing tag by adding the closing tag which is '</head>' just under the closing body tag
**Linked Issue**  
Closes #34 
