### PR TITLE
JCB card validation

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -13,6 +13,10 @@ const scheme_validators = [
     name: 'Visa',
     regex: /^4[0-9]{15}/,
   },
+  {
+    name: 'JCB',
+    regex: /^35[2-9]{1}[0-9]{13}/,
+  },
 ];
 
 function assign_scheme(number) {


### PR DESCRIPTION
JCB card starts with the range 3528 to 3589
As showed here: https://www.freeformatter.com/credit-card-number-generator-validator.html#cardFormats
Here I found some card numbers to test:
https://developers.bluesnap.com/docs/test-credit-cards

**Brief Description of Fix**

**Linked Issue**  
Closes #44 
